### PR TITLE
[codex] 为任务事件提醒新增 Bark 通知渠道

### DIFF
--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Application/Abstractions/IBarkAlertSender.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Application/Abstractions/IBarkAlertSender.cs
@@ -1,0 +1,12 @@
+using IGoLibrary.Ex.Application.Configuration;
+
+namespace IGoLibrary.Ex.Application.Abstractions;
+
+public interface IBarkAlertSender
+{
+    Task SendAsync(
+        BarkAlertChannelSettings settings,
+        string title,
+        string message,
+        CancellationToken cancellationToken = default);
+}

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Application/Abstractions/INotificationTestService.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Application/Abstractions/INotificationTestService.cs
@@ -8,5 +8,7 @@ public interface INotificationTestService
 
     Task SendTestTelegramAsync(TelegramAlertChannelSettings settings, CancellationToken cancellationToken = default);
 
+    Task SendTestBarkAsync(BarkAlertChannelSettings settings, CancellationToken cancellationToken = default);
+
     Task SendTestLocalAlertAsync(LocalDesktopAlertSettings settings, CancellationToken cancellationToken = default);
 }

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Application/Configuration/BarkAlertChannelSettings.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Application/Configuration/BarkAlertChannelSettings.cs
@@ -1,0 +1,18 @@
+namespace IGoLibrary.Ex.Application.Configuration;
+
+public sealed record BarkAlertChannelSettings(
+    bool Enabled,
+    string ServerUrl,
+    string DeviceKey,
+    string Sound,
+    string Group)
+{
+    public const string DefaultServerUrl = "https://api.day.app";
+
+    public static BarkAlertChannelSettings Default { get; } = new(
+        Enabled: false,
+        ServerUrl: DefaultServerUrl,
+        DeviceKey: string.Empty,
+        Sound: string.Empty,
+        Group: "IGoLibrary-Ex");
+}

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Application/Configuration/TaskEventAlertSettings.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Application/Configuration/TaskEventAlertSettings.cs
@@ -5,11 +5,13 @@ public sealed record TaskEventAlertSettings
     public TaskEventAlertSettings(
         EmailAlertChannelSettings email,
         LocalDesktopAlertSettings local,
-        TelegramAlertChannelSettings? telegram = null)
+        TelegramAlertChannelSettings? telegram = null,
+        BarkAlertChannelSettings? bark = null)
     {
         Email = email;
         Local = local;
         Telegram = telegram ?? TelegramAlertChannelSettings.Default;
+        Bark = bark ?? BarkAlertChannelSettings.Default;
     }
 
     public EmailAlertChannelSettings Email { get; init; }
@@ -18,8 +20,11 @@ public sealed record TaskEventAlertSettings
 
     public TelegramAlertChannelSettings Telegram { get; init; }
 
+    public BarkAlertChannelSettings Bark { get; init; }
+
     public static TaskEventAlertSettings Default { get; } = new(
         EmailAlertChannelSettings.Default,
         LocalDesktopAlertSettings.Default,
-        TelegramAlertChannelSettings.Default);
+        TelegramAlertChannelSettings.Default,
+        BarkAlertChannelSettings.Default);
 }

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/MainWindow.axaml
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/MainWindow.axaml
@@ -1526,7 +1526,7 @@
                           Padding="5"
                           Width="{Binding NotificationSegmentControlWidth}"
                           HorizontalAlignment="Center">
-                    <Grid ColumnDefinitions="*,*,*"
+                    <Grid ColumnDefinitions="*,*,*,*"
                           ColumnSpacing="6"
                           ClipToBounds="True">
                       <Border Background="{DynamicResource AppNotificationSegmentThumbBrush}"
@@ -1571,6 +1571,16 @@
                       </Grid>
 
                       <Grid Grid.Column="2">
+                        <Button Classes="notification-segment"
+                                Background="Transparent"
+                                Foreground="{Binding BarkNotificationTabForegroundBrush}"
+                                BorderThickness="0"
+                                CornerRadius="16"
+                                Content="Bark 推送"
+                                Command="{Binding ShowBarkNotificationSettingsCommand}" />
+                      </Grid>
+
+                      <Grid Grid.Column="3">
                         <Button Classes="notification-segment"
                                 Background="Transparent"
                                 Foreground="{Binding LocalNotificationTabForegroundBrush}"
@@ -1773,6 +1783,82 @@
                                 Background="{DynamicResource SemiAccentBrush}"
                                 Foreground="{DynamicResource AppAccentForegroundBrush}"
                                 MinWidth="176" />
+                      </Grid>
+                    </Grid>
+                  </Grid>
+
+                  <Grid HorizontalAlignment="Stretch">
+                    <Grid RowDefinitions="Auto,Auto,Auto"
+                          RowSpacing="18"
+                          HorizontalAlignment="Stretch">
+                      <StackPanel Grid.Row="0"
+                                  Spacing="0">
+                        <TextBlock Classes="field-label"
+                                   Text="Bark 服务器地址" />
+                        <TextBox Text="{Binding BarkAlertServerUrl}"
+                                 Watermark="https://api.day.app"
+                                 HorizontalAlignment="Stretch" />
+                      </StackPanel>
+
+                      <Grid Grid.Row="1"
+                            ColumnDefinitions="1.5*,*,*"
+                            ColumnSpacing="24">
+                        <StackPanel Grid.Column="0"
+                                    Spacing="0">
+                          <TextBlock Classes="field-label"
+                                     Text="Device Key" />
+                          <TextBox Text="{Binding BarkAlertDeviceKey}"
+                                   PasswordChar="●"
+                                   Watermark="从 Bark App 中复制 Device Key"
+                                   HorizontalAlignment="Stretch" />
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="1"
+                                    Spacing="0">
+                          <TextBlock Classes="field-label"
+                                     Text="提示音" />
+                          <TextBox Text="{Binding BarkAlertSound}"
+                                   Watermark="可选，例如 alarm"
+                                   HorizontalAlignment="Stretch" />
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="2"
+                                    Spacing="0">
+                          <TextBlock Classes="field-label"
+                                     Text="分组" />
+                          <TextBox Text="{Binding BarkAlertGroup}"
+                                   Watermark="IGoLibrary-Ex"
+                                   HorizontalAlignment="Stretch" />
+                        </StackPanel>
+                      </Grid>
+
+                      <Grid Grid.Row="2"
+                            ColumnDefinitions="*,Auto"
+                            ColumnSpacing="16"
+                            Margin="0,8,0,0">
+                        <Border Classes="notify-toggle-card">
+                          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+                            <StackPanel Spacing="4">
+                              <TextBlock FontSize="15"
+                                         FontWeight="SemiBold"
+                                         Text="开启 Bark 提醒" />
+                              <TextBlock Classes="helper-text"
+                                         Text="开启后，Cookie 失效、抢座成功、占座成功、明日预约成功和任务失败时，会通过 Bark 推送到手机" />
+                            </StackPanel>
+                            <ToggleSwitch Grid.Column="1"
+                                          IsChecked="{Binding BarkAlertsEnabled}"
+                                          OnContent="开"
+                                          OffContent="关"
+                                          VerticalAlignment="Center" />
+                          </Grid>
+                        </Border>
+
+                        <Button Grid.Column="1"
+                                Content="发送测试 Bark"
+                                Command="{Binding SendTestBarkAlertCommand}"
+                                Background="{DynamicResource SemiAccentBrush}"
+                                Foreground="{DynamicResource AppAccentForegroundBrush}"
+                                MinWidth="160" />
                       </Grid>
                     </Grid>
                   </Grid>
@@ -2298,6 +2384,5 @@
     </Grid>
   </Grid>
 </Window>
-
 
 

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/Services/DesktopNotificationTestService.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/Services/DesktopNotificationTestService.cs
@@ -6,6 +6,7 @@ namespace IGoLibrary.Ex.Desktop.Services;
 public sealed class DesktopNotificationTestService(
     IEmailAlertSender emailAlertSender,
     ITelegramAlertSender telegramAlertSender,
+    IBarkAlertSender barkAlertSender,
     ToastNotificationService toastNotificationService,
     AlertSoundService alertSoundService) : INotificationTestService
 {
@@ -37,6 +38,22 @@ public sealed class DesktopNotificationTestService(
             这是一条来自 IGoLibrary-Ex 的 Telegram 测试消息。
 
             如果你收到了这条消息，说明当前 Bot Token、Chat ID 和 API 地址已经可以正常工作，
+            可用于 Cookie 失效、抢座成功、占座成功和任务失败提醒。
+            """,
+            cancellationToken);
+    }
+
+    public Task SendTestBarkAsync(
+        BarkAlertChannelSettings settings,
+        CancellationToken cancellationToken = default)
+    {
+        return barkAlertSender.SendAsync(
+            settings,
+            "IGoLibrary-Ex Bark 测试",
+            """
+            这是一条来自 IGoLibrary-Ex 的 Bark 测试消息。
+
+            如果你收到了这条消息，说明当前 Bark 地址和 Device Key 已经可以正常工作，
             可用于 Cookie 失效、抢座成功、占座成功和任务失败提醒。
             """,
             cancellationToken);

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/Services/TaskEventAlertService.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/Services/TaskEventAlertService.cs
@@ -10,6 +10,7 @@ public sealed class TaskEventAlertService(
     ISettingsService settingsService,
     IEmailAlertSender emailAlertSender,
     ITelegramAlertSender telegramAlertSender,
+    IBarkAlertSender barkAlertSender,
     ToastNotificationService toastNotificationService,
     INotificationService notificationService,
     AlertSoundService alertSoundService,
@@ -37,6 +38,8 @@ public sealed class TaskEventAlertService(
             emailSubject: "IGoLibrary-Ex Cookie 失效提醒",
             emailBody: BuildSessionInvalidEmailBody(source, reason),
             telegramMessage: BuildSessionInvalidTelegramMessage(source, reason),
+            barkTitle: title,
+            barkMessage: detailMessage,
             toastKind: ToastVisualKind.Warning,
             toastTitle: title,
             toastMessage: detailMessage,
@@ -60,6 +63,8 @@ public sealed class TaskEventAlertService(
             emailSubject: "IGoLibrary-Ex 抢座成功提醒",
             emailBody: BuildGrabSucceededEmailBody(normalizedLibraryName, normalizedSeatName),
             telegramMessage: BuildGrabSucceededTelegramMessage(normalizedLibraryName, normalizedSeatName),
+            barkTitle: "抢座成功",
+            barkMessage: $"{normalizedLibraryName} · {normalizedSeatName} 已成功预约",
             toastKind: ToastVisualKind.Success,
             toastTitle: "抢座成功",
             toastMessage: $"{normalizedLibraryName} · {normalizedSeatName} 已成功预约",
@@ -82,6 +87,8 @@ public sealed class TaskEventAlertService(
             emailSubject: "IGoLibrary-Ex 占座成功提醒",
             emailBody: BuildOccupyReReserveSucceededEmailBody(normalizedSeatName),
             telegramMessage: BuildOccupyReReserveSucceededTelegramMessage(normalizedSeatName),
+            barkTitle: "占座成功",
+            barkMessage: $"{normalizedSeatName} 已重新预约",
             toastKind: ToastVisualKind.Success,
             toastTitle: "占座成功",
             toastMessage: $"{normalizedSeatName} 已重新预约",
@@ -110,6 +117,8 @@ public sealed class TaskEventAlertService(
             emailSubject: "IGoLibrary-Ex 明日预约成功提醒",
             emailBody: BuildTomorrowReservationSucceededEmailBody(normalizedLibraryName, normalizedSeatName, normalizedDay),
             telegramMessage: BuildTomorrowReservationSucceededTelegramMessage(normalizedLibraryName, normalizedSeatName, normalizedDay),
+            barkTitle: "明日预约成功",
+            barkMessage: $"{normalizedDay} · {normalizedLibraryName} · {normalizedSeatName} 已成功预约",
             toastKind: ToastVisualKind.Success,
             toastTitle: "明日预约成功",
             toastMessage: $"{normalizedDay} · {normalizedLibraryName} · {normalizedSeatName} 已成功预约",
@@ -133,6 +142,8 @@ public sealed class TaskEventAlertService(
             emailSubject: $"IGoLibrary-Ex {normalizedTaskName}任务失败提醒",
             emailBody: BuildTaskFailedEmailBody(normalizedTaskName, reason),
             telegramMessage: BuildTaskFailedTelegramMessage(normalizedTaskName, reason),
+            barkTitle: $"{normalizedTaskName}失败",
+            barkMessage: AppendDetail(message, reason),
             toastKind: ToastVisualKind.Warning,
             toastTitle: $"{normalizedTaskName}失败",
             toastMessage: AppendDetail(message, reason),
@@ -147,6 +158,8 @@ public sealed class TaskEventAlertService(
         string emailSubject,
         string emailBody,
         string telegramMessage,
+        string barkTitle,
+        string barkMessage,
         ToastVisualKind toastKind,
         string toastTitle,
         string toastMessage,
@@ -184,7 +197,7 @@ public sealed class TaskEventAlertService(
             await ShowInAppFallbackAsync(toastKind, toastTitle, toastMessage, cancellationToken);
         }
 
-        var remoteAlertTasks = new List<Task>(capacity: 2);
+        var remoteAlertTasks = new List<Task>(capacity: 3);
         if (alertSettings.Email.Enabled)
         {
             remoteAlertTasks.Add(SendEmailAlertSafelyAsync(
@@ -201,6 +214,16 @@ public sealed class TaskEventAlertService(
                 alertSettings.Telegram,
                 telegramLabel,
                 telegramMessage,
+                cancellationToken));
+        }
+
+        if (alertSettings.Bark.Enabled)
+        {
+            remoteAlertTasks.Add(SendBarkAlertSafelyAsync(
+                alertSettings.Bark,
+                localLabel,
+                barkTitle,
+                barkMessage,
                 cancellationToken));
         }
 
@@ -248,6 +271,27 @@ public sealed class TaskEventAlertService(
         catch (Exception ex)
         {
             activityLogService.Write(LogEntryKind.Warning, "Alert", $"发送{telegramLabel}Telegram提醒失败：{ex.Message}");
+        }
+    }
+
+    private async Task SendBarkAlertSafelyAsync(
+        BarkAlertChannelSettings settings,
+        string barkLabel,
+        string title,
+        string message,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await barkAlertSender.SendAsync(
+                settings,
+                title,
+                message,
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            activityLogService.Write(LogEntryKind.Warning, "Alert", $"发送{barkLabel}Bark提醒失败：{ex.Message}");
         }
     }
 

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/ViewModels/MainWindowWorkflowViewModel.Workflows.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/ViewModels/MainWindowWorkflowViewModel.Workflows.cs
@@ -81,13 +81,15 @@ public partial class MainWindowWorkflowViewModel
 
     public bool IsTelegramNotificationTabActive => SelectedNotificationSettingsTabIndex == 1;
 
-    public bool IsLocalNotificationTabActive => SelectedNotificationSettingsTabIndex == 2;
+    public bool IsBarkNotificationTabActive => SelectedNotificationSettingsTabIndex == 2;
+
+    public bool IsLocalNotificationTabActive => SelectedNotificationSettingsTabIndex == 3;
 
     public double NotificationSegmentControlWidth => NotificationSegmentControlWidthValue;
 
     public double NotificationSegmentSliderWidth => NotificationSegmentSliderWidthValue;
 
-    public double NotificationSegmentSliderOffset => Math.Clamp(SelectedNotificationSettingsTabIndex, 0, 2) *
+    public double NotificationSegmentSliderOffset => Math.Clamp(SelectedNotificationSettingsTabIndex, 0, 3) *
                                                      NotificationSegmentSliderOffsetValue;
 
     public IBrush EmailNotificationTabBackgroundBrush => IsEmailNotificationTabActive
@@ -98,7 +100,15 @@ public partial class MainWindowWorkflowViewModel
         ? NotificationSegmentActiveBrush
         : NotificationSegmentInactiveBrush;
 
+    public IBrush BarkNotificationTabBackgroundBrush => IsBarkNotificationTabActive
+        ? NotificationSegmentActiveBrush
+        : NotificationSegmentInactiveBrush;
+
     public IBrush TelegramNotificationTabForegroundBrush => IsTelegramNotificationTabActive
+        ? NotificationSegmentActiveTextBrush
+        : NotificationSegmentInactiveTextBrush;
+
+    public IBrush BarkNotificationTabForegroundBrush => IsBarkNotificationTabActive
         ? NotificationSegmentActiveTextBrush
         : NotificationSegmentInactiveTextBrush;
 
@@ -251,12 +261,15 @@ public partial class MainWindowWorkflowViewModel
     {
         OnPropertyChanged(nameof(IsEmailNotificationTabActive));
         OnPropertyChanged(nameof(IsTelegramNotificationTabActive));
+        OnPropertyChanged(nameof(IsBarkNotificationTabActive));
         OnPropertyChanged(nameof(IsLocalNotificationTabActive));
         OnPropertyChanged(nameof(NotificationSegmentSliderOffset));
         OnPropertyChanged(nameof(EmailNotificationTabBackgroundBrush));
+        OnPropertyChanged(nameof(BarkNotificationTabBackgroundBrush));
         OnPropertyChanged(nameof(LocalNotificationTabBackgroundBrush));
         OnPropertyChanged(nameof(EmailNotificationTabForegroundBrush));
         OnPropertyChanged(nameof(TelegramNotificationTabForegroundBrush));
+        OnPropertyChanged(nameof(BarkNotificationTabForegroundBrush));
         OnPropertyChanged(nameof(LocalNotificationTabForegroundBrush));
     }
 
@@ -454,6 +467,16 @@ public partial class MainWindowWorkflowViewModel
 
     partial void OnTelegramAlertChatIdChanged(string value) => ScheduleNotificationSettingsAutoSave();
 
+    partial void OnBarkAlertsEnabledChanged(bool value) => ScheduleNotificationSettingsAutoSave();
+
+    partial void OnBarkAlertServerUrlChanged(string value) => ScheduleNotificationSettingsAutoSave();
+
+    partial void OnBarkAlertDeviceKeyChanged(string value) => ScheduleNotificationSettingsAutoSave();
+
+    partial void OnBarkAlertSoundChanged(string value) => ScheduleNotificationSettingsAutoSave();
+
+    partial void OnBarkAlertGroupChanged(string value) => ScheduleNotificationSettingsAutoSave();
+
     partial void OnLocalToastAlertsEnabledChanged(bool value) => ScheduleNotificationSettingsAutoSave();
 
     partial void OnLocalSoundAlertsEnabledChanged(bool value) => ScheduleNotificationSettingsAutoSave();
@@ -500,6 +523,12 @@ public partial class MainWindowWorkflowViewModel
 
     [RelayCommand]
     private void ShowLocalNotificationSettings()
+    {
+        SelectedNotificationSettingsTabIndex = 3;
+    }
+
+    [RelayCommand]
+    private void ShowBarkNotificationSettings()
     {
         SelectedNotificationSettingsTabIndex = 2;
     }
@@ -1406,6 +1435,25 @@ public partial class MainWindowWorkflowViewModel
     }
 
     [RelayCommand]
+    private async Task SendTestBarkAlertAsync()
+    {
+        try
+        {
+            CancelPendingNotificationSettingsAutoSave();
+            await PersistNotificationSettingsSnapshotAsync();
+            await NotificationSettings.SendTestBarkAsync(BuildTaskEventAlertSettingsSnapshot().Bark);
+            NotificationSettingsStatusText = $"测试 Bark 已发送于 {DateTime.Now:HH:mm:ss}。";
+            await _notificationService.ShowSuccessAsync("测试 Bark 已发送", "请检查 Bark 客户端，确认当前 Device Key 可用");
+        }
+        catch (Exception ex)
+        {
+            NotificationSettingsStatusText = $"测试 Bark 发送失败：{ex.Message}";
+            _activityLogService.Write(LogEntryKind.Warning, "Alert", $"发送测试 Bark 失败：{ex.Message}");
+            await _errorDialogService.ShowErrorAsync("测试 Bark 发送失败", ex.GetType().Name, BuildExceptionDetails(ex));
+        }
+    }
+
+    [RelayCommand]
     private async Task SaveProtocolOverridesAsync()
     {
         var overrides = new TraceIntGraphQlTemplateOverrides(
@@ -1573,6 +1621,15 @@ public partial class MainWindowWorkflowViewModel
                 : alertSettings.Telegram.ApiBaseUrl;
             TelegramAlertBotToken = alertSettings.Telegram.BotToken ?? string.Empty;
             TelegramAlertChatId = alertSettings.Telegram.ChatId ?? string.Empty;
+            BarkAlertsEnabled = alertSettings.Bark.Enabled;
+            BarkAlertServerUrl = string.IsNullOrWhiteSpace(alertSettings.Bark.ServerUrl)
+                ? BarkAlertChannelSettings.DefaultServerUrl
+                : alertSettings.Bark.ServerUrl;
+            BarkAlertDeviceKey = alertSettings.Bark.DeviceKey ?? string.Empty;
+            BarkAlertSound = alertSettings.Bark.Sound ?? string.Empty;
+            BarkAlertGroup = string.IsNullOrWhiteSpace(alertSettings.Bark.Group)
+                ? BarkAlertChannelSettings.Default.Group
+                : alertSettings.Bark.Group;
             LocalToastAlertsEnabled = alertSettings.Local.PopupEnabled;
             LocalSoundAlertsEnabled = alertSettings.Local.SoundEnabled;
             NotificationSettingsStatusText = "更改后会自动保存。";
@@ -3201,7 +3258,13 @@ public partial class MainWindowWorkflowViewModel
                 TelegramAlertsEnabled,
                 NormalizeTelegramApiBaseUrlForSnapshot(TelegramAlertApiBaseUrl),
                 (TelegramAlertBotToken ?? string.Empty).Trim(),
-                (TelegramAlertChatId ?? string.Empty).Trim()));
+                (TelegramAlertChatId ?? string.Empty).Trim()),
+            new BarkAlertChannelSettings(
+                BarkAlertsEnabled,
+                NormalizeBarkServerUrlForSnapshot(BarkAlertServerUrl),
+                (BarkAlertDeviceKey ?? string.Empty).Trim(),
+                (BarkAlertSound ?? string.Empty).Trim(),
+                NormalizeBarkGroupForSnapshot(BarkAlertGroup)));
     }
 
     private static string NormalizeTelegramApiBaseUrlForSnapshot(string? value)
@@ -3209,6 +3272,22 @@ public partial class MainWindowWorkflowViewModel
         var trimmed = (value ?? string.Empty).Trim().TrimEnd('/');
         return string.IsNullOrWhiteSpace(trimmed)
             ? TelegramAlertChannelSettings.DefaultApiBaseUrl
+            : trimmed;
+    }
+
+    private static string NormalizeBarkServerUrlForSnapshot(string? value)
+    {
+        var trimmed = (value ?? string.Empty).Trim().TrimEnd('/');
+        return string.IsNullOrWhiteSpace(trimmed)
+            ? BarkAlertChannelSettings.DefaultServerUrl
+            : trimmed;
+    }
+
+    private static string NormalizeBarkGroupForSnapshot(string? value)
+    {
+        var trimmed = (value ?? string.Empty).Trim();
+        return string.IsNullOrWhiteSpace(trimmed)
+            ? BarkAlertChannelSettings.Default.Group
             : trimmed;
     }
 
@@ -3460,6 +3539,7 @@ public partial class MainWindowWorkflowViewModel
 
         OnPropertyChanged(nameof(EmailNotificationTabForegroundBrush));
         OnPropertyChanged(nameof(TelegramNotificationTabForegroundBrush));
+        OnPropertyChanged(nameof(BarkNotificationTabForegroundBrush));
         OnPropertyChanged(nameof(LocalNotificationTabForegroundBrush));
         OnPropertyChanged(nameof(GrabDashboardStatusBrush));
         OnPropertyChanged(nameof(TomorrowDashboardStatusBrush));

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/ViewModels/MainWindowWorkflowViewModel.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/ViewModels/MainWindowWorkflowViewModel.cs
@@ -128,7 +128,7 @@ public partial class MainWindowWorkflowViewModel(
     private static readonly IBrush NotificationSegmentInactiveBrush = Brushes.Transparent;
     private IBrush NotificationSegmentActiveTextBrush = appThemeService.CurrentPalette.NotificationSegmentActiveTextBrush;
     private IBrush NotificationSegmentInactiveTextBrush = appThemeService.CurrentPalette.NotificationSegmentInactiveTextBrush;
-    private const double NotificationSegmentControlWidthValue = 560d;
+    private const double NotificationSegmentControlWidthValue = 720d;
     private const double NotificationSegmentSliderWidthValue = 174d;
     private const double NotificationSegmentSliderOffsetValue = 180d;
     private readonly HashSet<string> _committedSelectedSeatKeys = new(StringComparer.Ordinal);
@@ -591,6 +591,21 @@ public partial class MainWindowWorkflowViewModel(
 
     [ObservableProperty]
     private string telegramAlertChatId = string.Empty;
+
+    [ObservableProperty]
+    private bool barkAlertsEnabled;
+
+    [ObservableProperty]
+    private string barkAlertServerUrl = BarkAlertChannelSettings.DefaultServerUrl;
+
+    [ObservableProperty]
+    private string barkAlertDeviceKey = string.Empty;
+
+    [ObservableProperty]
+    private string barkAlertSound = string.Empty;
+
+    [ObservableProperty]
+    private string barkAlertGroup = BarkAlertChannelSettings.Default.Group;
 
     [ObservableProperty]
     private bool localToastAlertsEnabled = true;

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/ViewModels/ShellPageViewModels.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Desktop/ViewModels/ShellPageViewModels.cs
@@ -181,6 +181,13 @@ public sealed partial class NotificationSettingsViewModel(
         return notificationTestService.SendTestTelegramAsync(settings, cancellationToken);
     }
 
+    public Task SendTestBarkAsync(
+        BarkAlertChannelSettings settings,
+        CancellationToken cancellationToken = default)
+    {
+        return notificationTestService.SendTestBarkAsync(settings, cancellationToken);
+    }
+
     public Task SendTestLocalAlertAsync(
         LocalDesktopAlertSettings settings,
         CancellationToken cancellationToken = default)

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Infrastructure/DependencyInjection.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Infrastructure/DependencyInjection.cs
@@ -31,6 +31,10 @@ public static class DependencyInjection
         {
             client.Timeout = Timeout.InfiniteTimeSpan;
         });
+        services.AddHttpClient<IBarkAlertSender, BarkAlertSender>(client =>
+        {
+            client.Timeout = Timeout.InfiniteTimeSpan;
+        });
         services.AddHttpClient<IGitHubReleaseClient, GitHubReleaseClient>(client =>
         {
             client.Timeout = Timeout.InfiniteTimeSpan;

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Infrastructure/Notifications/BarkAlertSender.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Infrastructure/Notifications/BarkAlertSender.cs
@@ -1,0 +1,248 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IGoLibrary.Ex.Application.Abstractions;
+using IGoLibrary.Ex.Application.Configuration;
+
+namespace IGoLibrary.Ex.Infrastructure.Notifications;
+
+internal sealed class BarkAlertSender(
+    HttpClient httpClient,
+    ISettingsService settingsService) : IBarkAlertSender
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public async Task SendAsync(
+        BarkAlertChannelSettings settings,
+        string title,
+        string message,
+        CancellationToken cancellationToken = default)
+    {
+        var normalized = Normalize(settings);
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            throw new InvalidOperationException("Bark 通知标题不能为空");
+        }
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            throw new InvalidOperationException("Bark 通知内容不能为空");
+        }
+
+        using var response = await ExecuteWithRequestPolicyAsync(
+            token => SendOnceAsync(normalized, title.Trim(), message.Trim(), token),
+            cancellationToken);
+        var raw = await response.Content.ReadAsStringAsync(cancellationToken);
+        ThrowIfBarkResponseFailed(response, raw);
+    }
+
+    internal static BarkAlertChannelSettings Normalize(BarkAlertChannelSettings settings)
+    {
+        var serverUrl = (settings.ServerUrl ?? string.Empty).Trim().TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(serverUrl))
+        {
+            throw new InvalidOperationException("请填写 Bark 服务器地址");
+        }
+
+        if (!Uri.TryCreate(serverUrl, UriKind.Absolute, out var uri) ||
+            uri.Scheme is not ("http" or "https"))
+        {
+            throw new InvalidOperationException("Bark 服务器地址必须是 http 或 https 绝对地址");
+        }
+
+        var deviceKey = (settings.DeviceKey ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(deviceKey))
+        {
+            throw new InvalidOperationException("请填写 Bark Device Key");
+        }
+
+        return settings with
+        {
+            ServerUrl = serverUrl,
+            DeviceKey = deviceKey,
+            Sound = (settings.Sound ?? string.Empty).Trim(),
+            Group = string.IsNullOrWhiteSpace(settings.Group) ? BarkAlertChannelSettings.Default.Group : settings.Group.Trim()
+        };
+    }
+
+    internal static Uri BuildPushUri(BarkAlertChannelSettings settings)
+    {
+        var normalized = Normalize(settings);
+        return new Uri($"{normalized.ServerUrl}/{Uri.EscapeDataString(normalized.DeviceKey)}");
+    }
+
+    internal static void ThrowIfBarkResponseFailed(HttpResponseMessage response, string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            throw new HttpRequestException(
+                $"Bark 请求失败，HTTP {(int)response.StatusCode} {response.StatusCode}",
+                null,
+                response.StatusCode);
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(raw);
+            var root = document.RootElement;
+            var code = ReadOptionalInt(root, "code");
+            if ((code is 200 || code is null) && response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var message = ReadOptionalString(root, "message");
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                message = $"HTTP {(int)response.StatusCode} {response.StatusCode}";
+            }
+
+            throw new InvalidOperationException(code is null
+                ? $"Bark API 返回失败：{message}"
+                : $"Bark API 返回失败(code={code})：{message}");
+        }
+        catch (JsonException ex)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(
+                    $"Bark 请求失败，HTTP {(int)response.StatusCode} {response.StatusCode}",
+                    ex,
+                    response.StatusCode);
+            }
+        }
+    }
+
+    private async Task<HttpResponseMessage> SendOnceAsync(
+        BarkAlertChannelSettings settings,
+        string title,
+        string message,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, BuildPushUri(settings))
+        {
+            Content = JsonContent.Create(
+                new BarkPushRequest(
+                    title,
+                    message,
+                    string.IsNullOrWhiteSpace(settings.Sound) ? null : settings.Sound,
+                    string.IsNullOrWhiteSpace(settings.Group) ? null : settings.Group),
+                options: JsonOptions)
+        };
+
+        return await httpClient.SendAsync(request, cancellationToken);
+    }
+
+    private async Task<HttpResponseMessage> ExecuteWithRequestPolicyAsync(
+        Func<CancellationToken, Task<HttpResponseMessage>> operation,
+        CancellationToken cancellationToken)
+    {
+        var settings = await LoadNetworkSettingsAsync(cancellationToken);
+        Exception? lastException = null;
+
+        for (var attempt = 0; attempt <= settings.MaxRetries; attempt++)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(settings.Timeout);
+
+            try
+            {
+                var response = await operation(timeoutCts.Token);
+                if (!IsTransient(response.StatusCode))
+                {
+                    return response;
+                }
+
+                lastException = new HttpRequestException(
+                    $"Bark 请求失败，HTTP {(int)response.StatusCode} {response.StatusCode}",
+                    null,
+                    response.StatusCode);
+                response.Dispose();
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+            {
+                lastException = new TimeoutException($"Bark 请求超时（>{settings.Timeout.TotalSeconds:0} 秒）。", ex);
+            }
+            catch (HttpRequestException ex) when (IsTransient(ex.StatusCode))
+            {
+                lastException = ex;
+            }
+
+            if (attempt >= settings.MaxRetries)
+            {
+                break;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(250 * (attempt + 1)), cancellationToken);
+        }
+
+        throw lastException ?? new InvalidOperationException("Bark 请求失败。");
+    }
+
+    private async Task<(TimeSpan Timeout, int MaxRetries)> LoadNetworkSettingsAsync(CancellationToken cancellationToken)
+    {
+        NetworkRequestSettings settings;
+        try
+        {
+            settings = (await settingsService.LoadAsync(cancellationToken)).Network;
+        }
+        catch
+        {
+            settings = NetworkRequestSettings.Default;
+        }
+
+        var timeoutSeconds = Math.Clamp(settings.TimeoutSeconds, 1, 60);
+        var maxRetries = Math.Clamp(settings.MaxRetries, 0, 10);
+        return (TimeSpan.FromSeconds(timeoutSeconds), maxRetries);
+    }
+
+    private static bool IsTransient(HttpStatusCode? statusCode)
+    {
+        return statusCode is null
+            or HttpStatusCode.RequestTimeout
+            or HttpStatusCode.TooManyRequests
+            or HttpStatusCode.BadGateway
+            or HttpStatusCode.ServiceUnavailable
+            or HttpStatusCode.GatewayTimeout;
+    }
+
+    private static int? ReadOptionalInt(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.Number when property.TryGetInt32(out var value) => value,
+            JsonValueKind.String when int.TryParse(property.GetString(), out var value) => value,
+            _ => null
+        };
+    }
+
+    private static string? ReadOptionalString(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.String ? property.GetString() : null;
+    }
+
+    private sealed record BarkPushRequest(
+        string Title,
+        string Body,
+        string? Sound,
+        string? Group);
+}

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Infrastructure/Notifications/BarkAlertSender.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Infrastructure/Notifications/BarkAlertSender.cs
@@ -212,7 +212,8 @@ internal sealed class BarkAlertSender(
             or HttpStatusCode.TooManyRequests
             or HttpStatusCode.BadGateway
             or HttpStatusCode.ServiceUnavailable
-            or HttpStatusCode.GatewayTimeout;
+            or HttpStatusCode.GatewayTimeout
+            || (int?)statusCode >= 500;
     }
 
     private static int? ReadOptionalInt(JsonElement root, string name)

--- a/IGoLibrary-Ex/src/IGoLibrary.Ex.Infrastructure/Persistence/SqliteSettingsRepository.cs
+++ b/IGoLibrary-Ex/src/IGoLibrary.Ex.Infrastructure/Persistence/SqliteSettingsRepository.cs
@@ -237,7 +237,8 @@ public sealed class SqliteSettingsRepository(
                 TaskEventAlerts = new TaskEventAlertSettings(
                     alertSettings.Email ?? EmailAlertChannelSettings.Default,
                     alertSettings.Local ?? LocalDesktopAlertSettings.Default,
-                    alertSettings.Telegram ?? TelegramAlertChannelSettings.Default)
+                    alertSettings.Telegram ?? TelegramAlertChannelSettings.Default,
+                    alertSettings.Bark ?? BarkAlertChannelSettings.Default)
             },
             Ui = ui with
             {
@@ -353,6 +354,8 @@ public sealed class SqliteSettingsRepository(
         WriteLocalDesktopAlert(writer, ReadObject(alerts, "local"), defaults.Local);
         writer.WritePropertyName("telegram");
         WriteObjectOrDefault(writer, ReadObject(alerts, "telegram"), defaults.Telegram);
+        writer.WritePropertyName("bark");
+        WriteObjectOrDefault(writer, ReadObject(alerts, "bark"), defaults.Bark);
         writer.WriteEndObject();
     }
 

--- a/IGoLibrary-Ex/tests/IGoLibrary.Ex.Tests/BarkAlertSenderTests.cs
+++ b/IGoLibrary-Ex/tests/IGoLibrary.Ex.Tests/BarkAlertSenderTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using System.Text.Json;
+using IGoLibrary.Ex.Domain.Models;
+using IGoLibrary.Ex.Infrastructure.Notifications;
+
+namespace IGoLibrary.Ex.Tests;
+
+public sealed class BarkAlertSenderTests
+{
+    [Fact]
+    public async Task SendAsync_PostsJsonToBarkPushEndpoint()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
+        var handler = new SequenceHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            capturedRequest = request;
+            capturedBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"code":200,"message":"success","timestamp":1710000000}""")
+            };
+        });
+        var sender = CreateSender(handler);
+
+        await sender.SendAsync(
+            new BarkAlertChannelSettings(true, "https://api.day.app/", "abc/key", "alarm", "Library"),
+            "抢座成功",
+            "自科阅览区一 · 2号座 已成功预约");
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(HttpMethod.Post, capturedRequest.Method);
+        Assert.Equal("https://api.day.app/abc%2Fkey", capturedRequest.RequestUri?.ToString());
+        using var document = JsonDocument.Parse(capturedBody!);
+        Assert.Equal("抢座成功", document.RootElement.GetProperty("title").GetString());
+        Assert.Equal("自科阅览区一 · 2号座 已成功预约", document.RootElement.GetProperty("body").GetString());
+        Assert.Equal("alarm", document.RootElement.GetProperty("sound").GetString());
+        Assert.Equal("Library", document.RootElement.GetProperty("group").GetString());
+    }
+
+    [Fact]
+    public async Task SendAsync_ThrowsReadableException_WhenBarkReturnsFailureCode()
+    {
+        var handler = new SequenceHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("""{"code":400,"message":"device key is invalid"}""")
+        }));
+        var sender = CreateSender(handler);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => sender.SendAsync(
+            new BarkAlertChannelSettings(true, "https://api.day.app", "device-key", string.Empty, "Library"),
+            "测试",
+            "测试消息"));
+
+        Assert.Contains("code=400", exception.Message);
+        Assert.Contains("device key is invalid", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_RetriesTransientHttpFailure_UsingSavedMaxRetries()
+    {
+        var handler = new SequenceHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent("temporary")
+            }),
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"code":200,"message":"success"}""")
+            }));
+        var sender = CreateSender(handler, AppSettings.Default with { Network = new NetworkRequestSettings(1, 1) });
+
+        await sender.SendAsync(
+            new BarkAlertChannelSettings(true, "https://api.day.app", "device-key", string.Empty, "Library"),
+            "测试",
+            "测试消息");
+
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Theory]
+    [InlineData("", "device-key", "请填写 Bark 服务器地址")]
+    [InlineData(null, "device-key", "请填写 Bark 服务器地址")]
+    [InlineData("api.day.app", "device-key", "Bark 服务器地址必须是 http 或 https 绝对地址")]
+    [InlineData("ftp://api.day.app", "device-key", "Bark 服务器地址必须是 http 或 https 绝对地址")]
+    [InlineData("https://api.day.app", "", "请填写 Bark Device Key")]
+    [InlineData("https://api.day.app", null, "请填写 Bark Device Key")]
+    public void Normalize_ValidatesRequiredSettings(string? serverUrl, string? deviceKey, string expectedMessage)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => BarkAlertSender.Normalize(
+            new BarkAlertChannelSettings(true, serverUrl!, deviceKey!, string.Empty, "Library")));
+
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    private static BarkAlertSender CreateSender(
+        HttpMessageHandler handler,
+        AppSettings? settings = null)
+    {
+        return new BarkAlertSender(
+            new HttpClient(handler)
+            {
+                Timeout = Timeout.InfiniteTimeSpan
+            },
+            new FakeSettingsService(settings ?? AppSettings.Default with
+            {
+                Network = AppSettings.Default.Network with { MaxRetries = 0 }
+            }));
+    }
+}

--- a/IGoLibrary-Ex/tests/IGoLibrary.Ex.Tests/SettingsSerializationTests.cs
+++ b/IGoLibrary-Ex/tests/IGoLibrary.Ex.Tests/SettingsSerializationTests.cs
@@ -92,6 +92,7 @@ public sealed class SettingsSerializationTests
         Assert.True(alerts.Local.PopupEnabled);
         Assert.False(alerts.Local.SoundEnabled);
         Assert.Equal(TelegramAlertChannelSettings.Default, alerts.Telegram);
+        Assert.Equal(BarkAlertChannelSettings.Default, alerts.Bark);
     }
 
     [Fact]
@@ -225,6 +226,7 @@ public sealed class SettingsSerializationTests
         Assert.Contains("\"dashboard\":", json);
         Assert.Contains("\"updates\":", json);
         Assert.Contains("\"taskEventAlerts\":", json);
+        Assert.Contains("\"bark\":", json);
         Assert.Contains("\"graphQlOverridesEnabled\": true", json);
     }
 

--- a/IGoLibrary-Ex/tests/IGoLibrary.Ex.Tests/TaskEventAlertServiceTests.cs
+++ b/IGoLibrary-Ex/tests/IGoLibrary.Ex.Tests/TaskEventAlertServiceTests.cs
@@ -15,6 +15,7 @@ public sealed class TaskEventAlertServiceTests
         var service = new DesktopNotificationTestService(
             new FakeEmailAlertSender(),
             new FakeTelegramAlertSender(),
+            new FakeBarkAlertSender(),
             new ToastNotificationService(settingsService, new AppWindowService()),
             new AlertSoundService());
         var settings = new EmailAlertChannelSettings(
@@ -295,6 +296,64 @@ public sealed class TaskEventAlertServiceTests
     }
 
     [Fact]
+    public async Task NotifyGrabSucceededAsync_SendsBarkUsingPersistedSettings()
+    {
+        var barkSender = new FakeBarkAlertSender();
+        var settingsService = new FakeSettingsService(WithTaskEventAlerts(
+            new TaskEventAlertSettings(
+                EmailAlertChannelSettings.Default with { Enabled = false },
+                new LocalDesktopAlertSettings(false, false),
+                TelegramAlertChannelSettings.Default with { Enabled = false },
+                new BarkAlertChannelSettings(true, "https://api.day.app", "device-key", "alarm", "Library"))));
+
+        var service = CreateService(settingsService: settingsService, barkSender: barkSender);
+
+        await service.NotifyGrabSucceededAsync("自科阅览区一", "2号座");
+
+        var request = Assert.Single(barkSender.Requests);
+        Assert.Equal("device-key", request.Settings.DeviceKey);
+        Assert.Equal("抢座成功", request.Title);
+        Assert.Contains("自科阅览区一", request.Message);
+        Assert.Contains("2号座", request.Message);
+    }
+
+    [Fact]
+    public async Task NotifyTaskFailedAsync_LogsWarningWhenBarkSendFails_AndContinuesEmail()
+    {
+        var emailSender = new FakeEmailAlertSender();
+        var barkSender = new FakeBarkAlertSender
+        {
+            SendException = new InvalidOperationException("bark boom")
+        };
+        var activityLog = new ActivityLogService();
+        var settingsService = new FakeSettingsService(WithTaskEventAlerts(
+            new TaskEventAlertSettings(
+                new EmailAlertChannelSettings(
+                    Enabled: true,
+                    SmtpHost: "smtp.example.com",
+                    Port: 587,
+                    SecurityMode: EmailSecurityMode.Tls,
+                    Username: "tester",
+                    Password: "secret",
+                    FromAddress: "sender@example.com",
+                    ToAddress: "receiver@example.com"),
+                new LocalDesktopAlertSettings(false, false),
+                TelegramAlertChannelSettings.Default with { Enabled = false },
+                new BarkAlertChannelSettings(true, "https://api.day.app", "device-key", string.Empty, "Library"))));
+
+        var service = CreateService(settingsService, emailSender, activityLog, barkSender: barkSender);
+
+        await service.NotifyTaskFailedAsync("抢座", "预约请求超时");
+
+        Assert.Single(emailSender.Requests);
+        Assert.Contains(
+            activityLog.Entries,
+            entry => entry.Kind == LogEntryKind.Warning
+                     && entry.Category == "Alert"
+                     && entry.Message.Contains("发送抢座任务失败提醒Bark提醒失败：bark boom", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task NotifyGrabSucceededAsync_ShowsInAppFallbackBeforeSlowTelegramCompletes()
     {
         var notificationService = new FakeNotificationService();
@@ -326,7 +385,8 @@ public sealed class TaskEventAlertServiceTests
         FakeEmailAlertSender? emailSender = null,
         ActivityLogService? activityLogService = null,
         INotificationService? notificationService = null,
-        FakeTelegramAlertSender? telegramSender = null)
+        FakeTelegramAlertSender? telegramSender = null,
+        FakeBarkAlertSender? barkSender = null)
     {
         settingsService ??= new FakeSettingsService(AppSettings.Default);
         var toastService = new ToastNotificationService(settingsService, new AppWindowService());
@@ -335,6 +395,7 @@ public sealed class TaskEventAlertServiceTests
             settingsService,
             emailSender ?? new FakeEmailAlertSender(),
             telegramSender ?? new FakeTelegramAlertSender(),
+            barkSender ?? new FakeBarkAlertSender(),
             toastService,
             notificationService ?? new FakeNotificationService(),
             new AlertSoundService(),

--- a/IGoLibrary-Ex/tests/IGoLibrary.Ex.Tests/TestDoubles.Notifications.cs
+++ b/IGoLibrary-Ex/tests/IGoLibrary.Ex.Tests/TestDoubles.Notifications.cs
@@ -63,11 +63,15 @@ internal sealed class FakeTaskEventAlertDispatcher : ITaskEventAlertDispatcher, 
 
     public List<TelegramAlertChannelSettings> TestTelegramRequests { get; } = [];
 
+    public List<BarkAlertChannelSettings> TestBarkRequests { get; } = [];
+
     public List<LocalDesktopAlertSettings> TestLocalAlertRequests { get; } = [];
 
     public Exception? SendTestEmailException { get; set; }
 
     public Exception? SendTestTelegramException { get; set; }
+
+    public Exception? SendTestBarkException { get; set; }
 
     public Exception? SendTestLocalException { get; set; }
 
@@ -149,6 +153,17 @@ internal sealed class FakeTaskEventAlertDispatcher : ITaskEventAlertDispatcher, 
         }
 
         TestTelegramRequests.Add(settings);
+        return Task.CompletedTask;
+    }
+
+    public Task SendTestBarkAsync(BarkAlertChannelSettings settings, CancellationToken cancellationToken = default)
+    {
+        if (SendTestBarkException is not null)
+        {
+            throw SendTestBarkException;
+        }
+
+        TestBarkRequests.Add(settings);
         return Task.CompletedTask;
     }
 
@@ -237,6 +252,28 @@ internal sealed class FakeTelegramAlertSender : ITelegramAlertSender
 
         Requests.Add((settings, message));
         return SendCompletion?.Task ?? Task.CompletedTask;
+    }
+}
+
+internal sealed class FakeBarkAlertSender : IBarkAlertSender
+{
+    public List<(BarkAlertChannelSettings Settings, string Title, string Message)> Requests { get; } = [];
+
+    public Exception? SendException { get; set; }
+
+    public Task SendAsync(
+        BarkAlertChannelSettings settings,
+        string title,
+        string message,
+        CancellationToken cancellationToken = default)
+    {
+        if (SendException is not null)
+        {
+            throw SendException;
+        }
+
+        Requests.Add((settings, title, message));
+        return Task.CompletedTask;
     }
 }
 


### PR DESCRIPTION
## 背景

IGoLibrary-Ex 在后台运行抢座、占座和明日预约任务时，很多关键结果需要及时知道。Bark 对 iOS 用户比较轻量，配置成本低，适合用来接收 Cookie 失效、预约成功、任务失败等远程提醒。

## 变更内容

- 新增 Bark 通知渠道，支持配置服务器地址、Device Key、提示音和分组。
- 在通知设置页新增 Bark 配置项和测试发送按钮。
- 将现有任务事件接入 Bark 通知：
  - Cookie 失效
  - 抢座成功
  - 占座成功
  - 明日预约成功
  - 任务失败
- Bark 发送失败时记录警告日志，不影响邮件、Telegram 和本地提醒继续发送。
- 补充 Bark 发送器、任务事件通知和设置序列化相关测试。

## 验证

- `git diff --check`
- `dotnet restore IGoLibrary-Ex.sln`
- `dotnet test IGoLibrary-Ex.sln --no-restore -m:1 /nodeReuse:false`

测试结果：292 通过，0 失败，0 跳过。
